### PR TITLE
Od gcw0 test

### DIFF
--- a/package/gmenu2x/0001-cmake-compilation.patch
+++ b/package/gmenu2x/0001-cmake-compilation.patch
@@ -1,0 +1,82 @@
+--- a/CMakeLists.txt	2020-02-04 09:54:13.000000000 +0100
++++ b/CMakeLists.txt	2020-02-04 09:57:14.000000000 +0100
+@@ -9,17 +9,17 @@
+
+ option(CPUFREQ "Enable CPU frequency control" OFF)
+ if (CPUFREQ)
+-	add_compile_definitions(ENABLE_CPUFREQ)
++	add_definitions(-DENABLE_CPUFREQ)
+ endif(CPUFREQ)
+
+ option(CLOCK "Display current time at the bottom of the screen" ON)
+ if (CLOCK)
+-	add_compile_definitions(ENABLE_CLOCK)
++	add_definitions(-DENABLE_CLOCK)
+ endif (CLOCK)
+
+ option(BIND_CONSOLE "Support for binding/unbinding terminal" OFF)
+ if (BIND_CONSOLE)
+-	add_compile_definitions(BIND_CONSOLE)
++	add_definitions(-DBIND_CONSOLE)
+ endif (BIND_CONSOLE)
+
+ set(PLATFORMS "pc, a320, gcw0, nanonote, rs90")
+@@ -30,28 +30,28 @@
+ set_property(CACHE PLATFORM PROPERTY STRINGS pc a320 gcw0 nanonote rs90)
+
+ if (PLATFORM MATCHES "a320")
+-	add_compile_definitions(PLATFORM_A320)
++	add_definitions(-DPLATFORM_A320)
+ 	set(SCREEN_RES "320x240")
+ elseif (PLATFORM MATCHES "gcw0")
+-	add_compile_definitions(PLATFORM_GCW0)
++	add_definitions(-DPLATFORM_GCW0)
+ 	set(SCREEN_RES "320x240")
+ elseif (PLATFORM MATCHES "rs90")
+-	add_compile_definitions(PLATFORM_RS90)
++	add_definitions(-DPLATFORM_RS90)
+ 	set(SCREEN_RES "240x160")
+ elseif (PLATFORM MATCHES "nanonote")
+-	add_compile_definitions(PLATFORM_NANONOTE)
++	add_definitions(-DPLATFORM_NANONOTE)
+ 	set(SCREEN_RES "320x240")
+ elseif (PLATFORM MATCHES "pandora")
+-	add_compile_definitions(PLATFORM_PANDORA)
++	add_definitions(-DPLATFORM_PANDORA)
+ 	set(SCREEN_RES "800x480")
+ elseif (PLATFORM MATCHES "pc")
+-	add_compile_definitions(PLATFORM_PC)
++	add_definitions(-DPLATFORM_PC)
+ 	set(SCREEN_RES "800x480")
+ else()
+ 	message(FATAL_ERROR "PLATFORM must be one of the following: ${PLATFORMS}")
+ endif(PLATFORM MATCHES "a320")
+
+-add_compile_definitions(PLATFORM="${PLATFORM}")
++add_definitions(-DPLATFORM="${PLATFORM}")
+
+ find_package(SDL REQUIRED)
+ find_package(SDL_ttf REQUIRED)
+@@ -77,11 +77,11 @@
+ if(LIBOPK_FOUND)
+ 	set(LIBOPK_LIBRARIES ${LIBOPK_LIBRARY})
+ 	set(LIBOPK_INCLUDE_DIRS ${LIBOPK_INCLUDE_DIR})
+-	add_compile_definitions(HAVE_LIBOPK)
++	add_definitions(-DHAVE_LIBOPK)
+
+ 	option(INOTIFY "Monitor OPK folder with inotify" ON)
+ 	if (INOTIFY)
+-		add_compile_definitions(ENABLE_INOTIFY)
++		add_definitions(-DENABLE_INOTIFY)
+ 	endif (INOTIFY)
+ endif(LIBOPK_FOUND)
+
+@@ -93,7 +93,7 @@
+ if (LIBXDGMIME_FOUND)
+ 	set(LIBXDGMIME_LIBRARIES ${LIBXDGMIME_LIBRARY})
+ 	set(LIBXDGMIME_INCLUDE_DIRS ${LIBXDGMIME_INCLUDE_DIR})
+-	add_compile_definitions(HAVE_LIBXDGMIME)
++	add_definitions(-DHAVE_LIBXDGMIME)
+ endif(LIBXDGMIME_FOUND)
+
+ file(GLOB OBJS src/*.cpp)

--- a/package/libglib2/0005-fix-gcc9-compilation-issue.patch
+++ b/package/libglib2/0005-fix-gcc9-compilation-issue.patch
@@ -1,0 +1,167 @@
+--- a/gio/gdbusauth.c 2020-02-03 20:27:23.000000000 +0100
++++ b/gio/gdbusauth.c 2020-02-03 20:30:00.000000000 +0100
+@@ -1299,9 +1299,9 @@
+                                                     &line_length,
+                                                     cancellable,
+                                                     error);
+-          debug_print ("SERVER: WaitingForBegin, read '%s'", line);
+           if (line == NULL)
+             goto out;
++          debug_print ("SERVER: WaitingForBegin, read '%s'", line);
+           if (g_strcmp0 (line, "BEGIN") == 0)
+             {
+               /* YAY, done! */
+--- a/gio/gdbusmessage.c	2020-02-03 20:27:39.000000000 +0100
++++ b/gio/gdbusmessage.c	2020-02-03 20:31:12.000000000 +0100
+@@ -88,7 +88,7 @@
+ g_memory_buffer_read_int16 (GMemoryBuffer  *mbuf)
+ {
+   gint16 v;
+-
++
+   if (mbuf->pos > mbuf->valid_len - 2)
+     {
+       mbuf->pos = mbuf->valid_len;
+@@ -108,7 +108,7 @@
+ g_memory_buffer_read_uint16 (GMemoryBuffer  *mbuf)
+ {
+   guint16 v;
+-
++
+   if (mbuf->pos > mbuf->valid_len - 2)
+     {
+       mbuf->pos = mbuf->valid_len;
+@@ -128,7 +128,7 @@
+ g_memory_buffer_read_int32 (GMemoryBuffer  *mbuf)
+ {
+   gint32 v;
+-
++
+   if (mbuf->pos > mbuf->valid_len - 4)
+     {
+       mbuf->pos = mbuf->valid_len;
+@@ -148,7 +148,7 @@
+ g_memory_buffer_read_uint32 (GMemoryBuffer  *mbuf)
+ {
+   guint32 v;
+-
++
+   if (mbuf->pos > mbuf->valid_len - 4)
+     {
+       mbuf->pos = mbuf->valid_len;
+@@ -168,7 +168,7 @@
+ g_memory_buffer_read_int64 (GMemoryBuffer  *mbuf)
+ {
+   gint64 v;
+-
++
+   if (mbuf->pos > mbuf->valid_len - 8)
+     {
+       mbuf->pos = mbuf->valid_len;
+@@ -188,7 +188,7 @@
+ g_memory_buffer_read_uint64 (GMemoryBuffer  *mbuf)
+ {
+   guint64 v;
+-
++
+   if (mbuf->pos > mbuf->valid_len - 8)
+     {
+       mbuf->pos = mbuf->valid_len;
+@@ -306,7 +306,7 @@
+     default:
+       break;
+     }
+-
++
+   return g_memory_buffer_write (mbuf, &data, 2);
+ }
+
+@@ -326,7 +326,7 @@
+     default:
+       break;
+     }
+-
++
+   return g_memory_buffer_write (mbuf, &data, 2);
+ }
+
+@@ -346,7 +346,7 @@
+     default:
+       break;
+     }
+-
++
+   return g_memory_buffer_write (mbuf, &data, 4);
+ }
+
+@@ -366,7 +366,7 @@
+     default:
+       break;
+     }
+-
++
+   return g_memory_buffer_write (mbuf, &data, 4);
+ }
+
+@@ -386,7 +386,7 @@
+     default:
+       break;
+     }
+-
++
+   return g_memory_buffer_write (mbuf, &data, 8);
+ }
+
+@@ -406,7 +406,7 @@
+     default:
+       break;
+     }
+-
++
+   return g_memory_buffer_write (mbuf, &data, 8);
+ }
+
+@@ -2727,7 +2727,6 @@
+   if (message->body != NULL)
+     {
+       gchar *tupled_signature_str;
+-      tupled_signature_str = g_strdup_printf ("(%s)", signature_str);
+       if (signature == NULL)
+         {
+           g_set_error (error,
+@@ -2738,7 +2737,8 @@
+           g_free (tupled_signature_str);
+           goto out;
+         }
+-      else if (g_strcmp0 (tupled_signature_str, g_variant_get_type_string (message->body)) != 0)
++      tupled_signature_str = g_strdup_printf ("(%s)", signature_str);
++      if (g_strcmp0 (tupled_signature_str, g_variant_get_type_string (message->body)) != 0)
+         {
+           g_set_error (error,
+                        G_IO_ERROR,
+@@ -3507,10 +3507,10 @@
+               fs = g_string_new (NULL);
+               if (fstat (fds[n], &statbuf) == 0)
+                 {
+-#ifndef MAJOR_MINOR_NOT_FOUND
++#ifndef MAJOR_MINOR_NOT_FOUND
+                   g_string_append_printf (fs, "%s" "dev=%d:%d", fs->len > 0 ? "," : "",
+                                           (gint) major (statbuf.st_dev), (gint) minor (statbuf.st_dev));
+-#endif
++#endif
+                   g_string_append_printf (fs, "%s" "mode=0%o", fs->len > 0 ? "," : "",
+                                           (guint) statbuf.st_mode);
+                   g_string_append_printf (fs, "%s" "ino=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",
+@@ -3519,10 +3519,10 @@
+                                           (guint) statbuf.st_uid);
+                   g_string_append_printf (fs, "%s" "gid=%u", fs->len > 0 ? "," : "",
+                                           (guint) statbuf.st_gid);
+-#ifndef MAJOR_MINOR_NOT_FOUND
++#ifndef MAJOR_MINOR_NOT_FOUND
+                   g_string_append_printf (fs, "%s" "rdev=%d:%d", fs->len > 0 ? "," : "",
+                                           (gint) major (statbuf.st_rdev), (gint) minor (statbuf.st_rdev));
+-#endif
++#endif
+                   g_string_append_printf (fs, "%s" "size=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",
+                                           (guint64) statbuf.st_size);
+                   g_string_append_printf (fs, "%s" "atime=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",

--- a/package/libglib2/libglib2.hash
+++ b/package/libglib2/libglib2.hash
@@ -1,4 +1,4 @@
-# https://download.gnome.org/sources/glib/2.56/glib-2.56.3.sha256sum
-sha256  a9a4c5b4c81b6c75bc140bdf5e32120ef3ce841b7413214ecf5f987acec74cb2  glib-2.56.3.tar.xz
+# https://download.gnome.org/sources/glib/2.56/glib-2.56.4.sha256sum
+sha256 27f703d125efb07f8a743666b580df0b4095c59fc8750e8890132c91d437504c  glib-2.56.4.tar.xz
 # License files, locally calculated
 sha256	dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551  COPYING

--- a/package/libglib2/libglib2.mk
+++ b/package/libglib2/libglib2.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 LIBGLIB2_VERSION_MAJOR = 2.56
-LIBGLIB2_VERSION = $(LIBGLIB2_VERSION_MAJOR).3
+LIBGLIB2_VERSION = $(LIBGLIB2_VERSION_MAJOR).4
 LIBGLIB2_SOURCE = glib-$(LIBGLIB2_VERSION).tar.xz
 LIBGLIB2_SITE = http://ftp.gnome.org/pub/gnome/sources/glib/$(LIBGLIB2_VERSION_MAJOR)
 LIBGLIB2_LICENSE = LGPL-2.1+

--- a/package/libopk/0001-cmake-compilation.patch
+++ b/package/libopk/0001-cmake-compilation.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2019-04-15 15:29:26.000000000 +0200
++++ b/CMakeLists.txt	2019-04-15 15:29:26.000000000 +0200
+@@ -21,7 +21,7 @@ include_directories(${INI_INCLUDE_DIRS})
+
+ pkg_check_modules(ZLIB QUIET zlib)
+ if (ZLIB_FOUND)
+-	add_compile_definitions(USE_GZIP)
++	add_definitions(-DUSE_GZIP)
+ 	link_directories(${ZLIB_LIBRARY_DIRS})
+ 	include_directories(${ZLIB_INCLUDE_DIRS})
+ endif (ZLIB_FOUND)

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -2,12 +2,12 @@
 set -e
 
 # Use the default config.
-make od_rs90_defconfig
+make od_gcw0_defconfig
 
 # Clear the install location.
 echo "Clearing install location..."
-mkdir -p /opt/rs90-toolchain
-rm -rf /opt/rs90-toolchain/*
+mkdir -p /opt/gcw0-toolchain
+rm -rf /opt/gcw0-toolchain/*
 
 # Clear the build location.
 echo "Clearing build location..."
@@ -19,4 +19,4 @@ nice make
 
 # Create packages.
 echo "Creating packages..."
-tar -C/opt --exclude='.fakeroot.*' -jcf opendingux-rs90-toolchain.`date +'%Y-%m-%d'`.tar.bz2 rs90-toolchain
+tar -C/opt --exclude='.fakeroot.*' -jcf opendingux-gcw0-toolchain.`date +'%Y-%m-%d'`.tar.bz2 gcw0-toolchain


### PR DESCRIPTION
Please find some minor compilation fix

CMake compilation fix about
add_compile_definitions(*) => add_definitions(-D*)
add_compile_definitions() was introduced in cmake 3.12 but this buildroot is using cmake 3.8

GCC9 compilation fix from
https://gitlab.gnome.org/GNOME/glib/merge_requests/626/diffs#note_422501