### PR TITLE
Add glebm's fork of DinguxCommander

### DIFF
--- a/board/opendingux/Config.in
+++ b/board/opendingux/Config.in
@@ -1,5 +1,6 @@
 menu "OpenDingux packages"
 
+	source "$BR2_EXTERNAL_OPENDINGUX_PATH/package/dingux-commander/Config.in"
 	source "$BR2_EXTERNAL_OPENDINGUX_PATH/package/gmenu2x/Config.in"
 	source "$BR2_EXTERNAL_OPENDINGUX_PATH/package/libhugetlbfs/Config.in"
 	source "$BR2_EXTERNAL_OPENDINGUX_PATH/package/libini/Config.in"

--- a/board/opendingux/package/dingux-commander/Config.in
+++ b/board/opendingux/package/dingux-commander/Config.in
@@ -1,0 +1,8 @@
+config BR2_PACKAGE_DINGUX_COMMANDER
+	bool "DinguxCommander"
+	select BR2_PACKAGE_SDL
+	select BR2_PACKAGE_SDL_IMAGE
+	help
+	  Two-pane file manager in the style of Norton Commander.
+
+	  https://github.com/glebm/rs97-commander/

--- a/board/opendingux/package/dingux-commander/dingux-commander.hash
+++ b/board/opendingux/package/dingux-commander/dingux-commander.hash
@@ -1,0 +1,1 @@
+sha256 d2390b09f9c86f42029b531dd568977305fd65f33739fe1bc73db36ced17b903  dl/dingux-commander/dingux-commander-d779431fbfda9c32d86b3dd28da71da4195f81c3.tar.gz

--- a/board/opendingux/package/dingux-commander/dingux-commander.mk
+++ b/board/opendingux/package/dingux-commander/dingux-commander.mk
@@ -1,0 +1,20 @@
+################################################################################
+#
+# DinguxCommander
+#
+################################################################################
+
+DINGUX_COMMANDER_VERSION = d779431fbfda9c32d86b3dd28da71da4195f81c3
+DINGUX_COMMANDER_SITE = $(call github,glebm,rs97-commander,$(DINGUX_COMMANDER_VERSION))
+DINGUX_COMMANDER_DEPENDENCIES = sdl sdl_image freetype
+
+DINGUX_COMMANDER_TARGET_PLATFORM = $(call qstrip,$(BR2_TOOLCHAIN_BUILDROOT_VENDOR))
+DINGUX_COMMANDER_CONF_OPTS += -DTARGET_PLATFORM=$(DINGUX_COMMANDER_TARGET_PLATFORM)
+
+define DINGUX_COMMANDER_INSTALL_TARGET_CMDS
+	mkdir -p $(BINARIES_DIR)/opks
+	cd $(@D) && ./package-opk.sh $(DINGUX_COMMANDER_TARGET_PLATFORM) $(DINGUX_COMMANDER_BUILDDIR) \
+	  $(BINARIES_DIR)/opks/commander.opk
+endef
+
+$(eval $(cmake-package))


### PR DESCRIPTION
This version of DinguxCommander is resolution-independent, has an image viewer, and fixes a number of bugs.

This just adds a package but does not enable it in defconfig.
Haven't tested as I don't have a device to test this buildroot with.

OPKs built from this PR:

RS90: [commander-rs90.opk.zip](https://github.com/OpenDingux/buildroot/files/4397803/commander-rs90.opk.zip)

