### PR TITLE
opendingux: Link etc/TZ to etc/local/TZ

### DIFF
--- a/board/opendingux/target_skeleton/etc/TZ
+++ b/board/opendingux/target_skeleton/etc/TZ
@@ -1,0 +1,1 @@
+local/TZ

--- a/configs/od_gcw0_defconfig
+++ b/configs/od_gcw0_defconfig
@@ -21,7 +21,6 @@ BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 BR2_ROOTFS_DEVICE_TABLE="board/opendingux/device_table.txt"
 BR2_ROOTFS_MERGED_USR=y
 BR2_SYSTEM_ENABLE_NLS=y
-BR2_TARGET_TZ_INFO=y
 BR2_ROOTFS_USERS_TABLES="board/opendingux/users.txt"
 BR2_ROOTFS_OVERLAY="board/opendingux/gcw0/overlay"
 BR2_ROOTFS_POST_BUILD_SCRIPT="board/opendingux/gcw0/cleanup-rootfs.sh"


### PR DESCRIPTION
This allows the timezone to be set by the user. If we do not disable the
timezone option in the buildroot configuration, buildroot will replace the link
with its own link pointing to a UTC timzeone file which we do not want. But
since UTC is the default anyway it doesnt matter if we just remove it.