### PR TITLE
opendingux: Save volume information correctly

### DIFF
--- a/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
@@ -15,7 +15,7 @@ case "$1" in
 		;;
 	stop)
 		echo "Storing sound volume..."
-		echo `/usr/bin/alsa-getvolume default $CONTROL` > $VOLUME_STATEFILE
+		amixer get $CONTROL | sed -n 's/.*Front .*: Playback \([0-9]*\).*$/\1/p' | paste -d "," - - > $VOLUME_STATEFILE
 		;;
 	*)
 		echo "Usage: $0 {start|stop}"


### PR DESCRIPTION
Previously the volume information was not saved properly on shutdown and this
patch solves that by reading volume from amixer and storing it in a state file.

Signed-off-by: Jens Nyberg <jens.nyberg@gmail.com>