### PR TITLE
opendingux: Update libshake and add backwards compat symlink

### DIFF
--- a/board/opendingux/package/libshake/libshake.hash
+++ b/board/opendingux/package/libshake/libshake.hash
@@ -1,1 +1,2 @@
-sha256	685984d60e98e57544a231eae024ca67c3bd9d1f7b8a0fb7c064c925789ffa18	libshake-8ca1aaf.tar.gz
+# Locally calculated
+sha256	b94279e201aba98269e013d0246af8ac2e6ba017bf821f6e03572521d85f1e0a	libshake-v0.3.2.tar.gz

--- a/board/opendingux/package/libshake/libshake.mk
+++ b/board/opendingux/package/libshake/libshake.mk
@@ -3,7 +3,7 @@
 # libshake
 #
 #############################################################
-LIBSHAKE_VERSION = 8ca1aaf
+LIBSHAKE_VERSION = v0.3.2
 LIBSHAKE_SITE = $(call github,zear,libShake,$(LIBSHAKE_VERSION))
 LIBSHAKE_LICENSE = MIT
 LIBSHAKE_LICENSE_FILES = LICENSE.txt
@@ -21,6 +21,12 @@ endef
 
 define LIBSHAKE_INSTALL_TARGET_CMDS
 	$(LIBSHAKE_MAKE_ENV) DESTDIR="$(TARGET_DIR)" $(MAKE) -C $(@D) BACKEND=LINUX install-lib
+
+	# libshake.so.1 symlink for backwards compatibility with existing OPKs.
+	# The API changes are [minimal][1] and do not seem to affect any existing OPKs.
+	#
+	# [1]: https://github.com/zear/libShake/commit/fb9b9e2c0ab391949317778e710aa8c235684783
+	ln -sf libshake.so.2 "$(TARGET_DIR)/usr/lib/libshake.so.1"
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
* Updates libshake while maintaining backwards compatibility.
* Fixes libshake's broken `so` symlink.

Signed-off-by: Gleb Mazovetskiy <glex.spb@gmail.com>