### PR TITLE
S90volume.sh : also save headphones volume

### DIFF
--- a/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
@@ -4,22 +4,24 @@
 #
 
 VOLUME_STATEFILE=/usr/local/etc/volume.state
-CONTROL=PCM
 
 case "$1" in
-	start)
-		echo "Loading sound volume..."
-		if [ -f $VOLUME_STATEFILE ]; then
-			/usr/bin/amixer set $CONTROL `cat $VOLUME_STATEFILE`
-		fi
-		;;
-	stop)
-		echo "Storing sound volume..."
-		amixer get $CONTROL | sed -n 's/.*Front .*: Playback \([0-9]*\).*$/\1/p' | paste -d "," - - > $VOLUME_STATEFILE
-		;;
-	*)
-		echo "Usage: $0 {start|stop}"
-		exit 1
+        start)
+                echo "Loading sound volume..."
+                if [ -f $VOLUME_STATEFILE ]; then
+                        /usr/bin/amixer set PCM `head -1 $VOLUME_STATEFILE`
+                        /usr/bin/amixer set Headphones `head -2 $VOLUME_STATEFILE`
+                fi
+                ;;
+        stop)
+                echo "Storing sound volume..."
+                PCM_VOL=`amixer get PCM | sed -n 's/.*Front .*: Playback \([0-9]*\).*$/\1/p' | paste -d "," - -`
+                HP_VOL=`amixer get Headphones | sed -n 's/.*Front .*: Playback \([0-9]*\).*$/\1/p' | paste -d "," - -`
+                printf "$PCM_VOL\n$HP_VOL\n" > $VOLUME_STATEFILE
+                ;;
+        *)
+                echo "Usage: $0 {start|stop}"
+                exit 1
 esac
 
 exit $?

--- a/board/opendingux/target_skeleton/usr/share/gmenu2x/sections/settings/40_alsamixer
+++ b/board/opendingux/target_skeleton/usr/share/gmenu2x/sections/settings/40_alsamixer
@@ -1,0 +1,6 @@
+title=Sound Mixer
+description=Configure sound settings
+icon=skin:icons/alsamixer.png
+exec=/usr/bin/alsamixer
+consoleapp=true
+editable=false


### PR DESCRIPTION
To ensure a smooth transition with the older format, just add a line below the PCM volume for headphones
in /usr/local/etc/volume.state

Signed-off-by: Christophe Branchereau <cbranchereau@gmail.com>