### PR TITLE
Gmenu2x : Add alsamixergui in the settings section

### DIFF
--- a/board/opendingux/target_skeleton/usr/share/gmenu2x/sections/settings/40_alsamixer
+++ b/board/opendingux/target_skeleton/usr/share/gmenu2x/sections/settings/40_alsamixer
@@ -1,0 +1,6 @@
+title=Sound Mixer
+description=Configure sound settings
+icon=skin:icons/alsamixer.png
+exec=/usr/bin/alsamixer
+consoleapp=true
+editable=false


### PR DESCRIPTION
This is useful to change the headphones volume independently from PCM

Signed-off-by: Christophe Branchereau <cbranchereau@gmail.com>