### PR TITLE
S90volume.sh : also store headphones volume

### DIFF
--- a/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
@@ -4,22 +4,24 @@
 #
 
 VOLUME_STATEFILE=/usr/local/etc/volume.state
-CONTROL=PCM
 
 case "$1" in
-	start)
-		echo "Loading sound volume..."
-		if [ -f $VOLUME_STATEFILE ]; then
-			/usr/bin/amixer set $CONTROL `cat $VOLUME_STATEFILE`
-		fi
-		;;
-	stop)
-		echo "Storing sound volume..."
-		amixer get $CONTROL | sed -n 's/.*Front .*: Playback \([0-9]*\).*$/\1/p' | paste -d "," - - > $VOLUME_STATEFILE
-		;;
-	*)
-		echo "Usage: $0 {start|stop}"
-		exit 1
+        start)
+                echo "Loading sound volume..."
+                if [ -f $VOLUME_STATEFILE ]; then
+                        /usr/bin/amixer set PCM `head -1 $VOLUME_STATEFILE`
+                        /usr/bin/amixer set Headphones `head -2 $VOLUME_STATEFILE`
+                fi
+                ;;
+        stop)
+                echo "Storing sound volume..."
+                PCM_VOL=`amixer get PCM | sed -n 's/.*Front .*: Playback \([0-9]*\).*$/\1/p' | paste -d "," - -`
+                HP_VOL=`amixer get Headphones | sed -n 's/.*Front .*: Playback \([0-9]*\).*$/\1/p' | paste -d "," - -`
+                printf "$PCM_VOL\n$HP_VOL\n" > $VOLUME_STATEFILE
+                ;;
+        *)
+                echo "Usage: $0 {start|stop}"
+                exit 1
 esac
 
 exit $?


### PR DESCRIPTION
This is useful, because the minimum volume is very loud when only PCM is adjustable.

Kept the old format and just added one line for Headphones below, to ensure a smooth transition that keeps users settings.

Signed-off-by: Christophe Branchereau <cbranchereau@gmail.com>