### PR TITLE
Fix libhugetlbfs URL

### DIFF
--- a/board/opendingux/package/libhugetlbfs/libhugetlbfs.mk
+++ b/board/opendingux/package/libhugetlbfs/libhugetlbfs.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 LIBHUGETLBFS_VERSION = 2.21
-LIBHUGETLBFS_SITE = $(call github,libhugetlbfs,libhugetlbfs,$(LIBHUGETLBFS_VERSION))
+LIBHUGETLBFS_SITE = https://github.com/libhugetlbfs/libhugetlbfs/releases/download/$(LIBHUGETLBFS_VERSION)
 LIBHUGETLBFS_INSTALL_STAGING = YES
 LIBHUGETLBFS_DEPENDENCIES += host-libhugetlbfs
 


### PR DESCRIPTION
With the old URL the build failed with the error

```
>>> libhugetlbfs 2.21 Building
CFLAGS="-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2  " LDFLAGS="" CC="/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-gcc" LD="/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-ld" ARCH=mips PREFIX=/usr /usr/bin/make -j5 -C /opt/buildroot/output/build/libhugetlbfs-2.21 V=1 libs
make[1]: Entering directory '/opt/buildroot/output/build/libhugetlbfs-2.21'
./localversion version ./libhugetlbfs_internal.h ./libhugetlbfs_testprobes.h ./libhugetlbfs_debug.h ./kernel-features.h ./libhugetlbfs_privutils.h ./hugetlbfs.h *.c *.lds Makefile
./localversion: ERROR: unversioned tarball
/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-gcc -D__LIBHUGETLBFS__ -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2   -Wall -fPIC -o obj32/elflink.o -c elflink.c
/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-gcc -D__LIBHUGETLBFS__ -o obj32/sys-elf_mips.o -c sys-elf_mips.S
/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-gcc -D__LIBHUGETLBFS__ -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2   -Wall -fPIC -o obj32/hugeutils.o -c hugeutils.c
/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-gcc -D__LIBHUGETLBFS__ -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2   -Wall -fPIC -o obj32/version.o -c version.c
hugeutils.c:20: warning: "_LARGEFILE64_SOURCE" redefined
   20 | #define _LARGEFILE64_SOURCE /* Need this for statfs64 */
      | 
<command-line>: note: this is the location of the previous definition
/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-gcc -D__LIBHUGETLBFS__ -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2   -Wall -fPIC -o obj32/init.o -c init.c
In file included from version.c:1:
version.h:1:2: error: #error UNVERSIONED tarball
    1 | #error UNVERSIONED tarball
      |  ^~~~~
version.c:3:55: error: expected ',' or ';' before 'VERSION'
    3 | static const char libhugetlbfs_version[] = "VERSION: "VERSION;
      |                                                       ^~~~~~~
version.c:3:19: warning: 'libhugetlbfs_version' defined but not used [-Wunused-const-variable=]
    3 | static const char libhugetlbfs_version[] = "VERSION: "VERSION;
      |                   ^~~~~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:297: obj32/version.o] Error 1
make[1]: *** Waiting for unfinished jobs....
/opt/buildroot/output/host/bin/mipsel-gcw0-linux-uclibc-gcc -D__LIBHUGETLBFS__ -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2   -Wall -fPIC -o obj32/morecore.o -c morecore.c
In file included from elflink.c:42:
version.h:1:2: error: #error UNVERSIONED tarball
    1 | #error UNVERSIONED tarball
      |  ^~~~~
In file included from elflink.c:44:
elflink.c: In function '__lh_hugetlbfs_setup_elflink':
elflink.c:1297:37: error: 'VERSION' undeclared (first use in this function); did you mean 'NT_VERSION'?
 1297 |  INFO("libhugetlbfs version: %s\n", VERSION);
      |                                     ^~~~~~~
libhugetlbfs_internal.h:145:7: note: in definition of macro 'REPORT'
  145 |     ##__VA_ARGS__); \
      |       ^~~~~~~~~~~
elflink.c:1297:2: note: in expansion of macro 'INFO'
 1297 |  INFO("libhugetlbfs version: %s\n", VERSION);
      |  ^~~~
elflink.c:1297:37: note: each undeclared identifier is reported only once for each function it appears in
 1297 |  INFO("libhugetlbfs version: %s\n", VERSION);
      |                                     ^~~~~~~
libhugetlbfs_internal.h:145:7: note: in definition of macro 'REPORT'
  145 |     ##__VA_ARGS__); \
      |       ^~~~~~~~~~~
elflink.c:1297:2: note: in expansion of macro 'INFO'
 1297 |  INFO("libhugetlbfs version: %s\n", VERSION);
      |  ^~~~
make[1]: *** [Makefile:296: obj32/elflink.o] Error 1
make[1]: Leaving directory '/opt/buildroot/output/build/libhugetlbfs-2.21'
make: *** [package/pkg-generic.mk:250: /opt/buildroot/output/build/libhugetlbfs-2.21/.stamp_built] Error 2
The command '/bin/sh -c make sdk BR2_SDK_PREFIX=${CONFIG}-toolchain' returned a non-zero code: 2
make[1]: *** [support/misc/docker.mk:26: docker-image] Помилка 2
make[1]: Залишаю каталог "/home/sergiy/Work/Playgo/buildroot"
make: *** [support/misc/docker.mk:12: gcw0-docker-image] Помилка 2
```

Likely it's related to https://github.com/libhugetlbfs/libhugetlbfs/issues/7, and the right URL fixes the issue