### PR TITLE
od: od-update: Add device selection menu

### DIFF
--- a/board/opendingux/create-opk.sh
+++ b/board/opendingux/create-opk.sh
@@ -56,6 +56,7 @@ ${HOST_DIR}/usr/bin/mksquashfs \
 	board/opendingux/opendingux_icon.png \
 	board/opendingux/opk_update_script.sh \
 	${TARGET_DIR}/usr/sbin/od-update \
+	${TARGET_DIR}/usr/bin/thisdevice \
 	${BINARIES_DIR}/${CONFIG}-update-${DATE}.opk \
 	-noappend -no-xattrs -all-root
 

--- a/board/opendingux/opk_update_script.sh
+++ b/board/opendingux/opk_update_script.sh
@@ -73,6 +73,18 @@ if [ $ERR -ne 0 ] ; then
 		11)
 			ERR_MSG="Updated bootloader is corrupted!\nPlease report this bug!"
 			;;
+		12)
+			ERR_MSG="Can't detect the device.\nPlease ensure that you are running a stock firmware"
+			;;
+		13)
+			ERR_MSG="Bootloader file $BOOTLOADER is missing\nPlease report this bug!"
+			;;
+		14)
+			ERR_MSG="Device tree file $DEVICETREE is missing\nPlease report this bug!"
+			;;
+		*)
+			ERR_MSG="Unexpected return code: $ERR\nPlease report this bug!"
+			;;
 	esac
 
 	export DIALOGRC="/tmp/dialog_err.rc"

--- a/board/opendingux/opk_update_script.sh
+++ b/board/opendingux/opk_update_script.sh
@@ -4,6 +4,85 @@ cd `dirname $0`
 
 DATE_FILE=./date.txt
 
+export DIALOGOPTS="--colors --no-shadow"
+if [ -f "$DATE_FILE" ] ; then
+	DATE="`cat $DATE_FILE`"
+	export DIALOGOPTS="$DIALOGOPTS --backtitle \"OpenDingux update $DATE\""
+fi
+
+echo "screen_color = (RED,RED,ON)" > /tmp/dialog_err.rc
+
+# ----------
+# 1. Select and confirm device
+# ----------
+THISDEVICE=./thisdevice
+DEVICE=$($THISDEVICE --detect)
+while true; do
+	if [ -n "$DEVICE" ]; then
+		eval $($THISDEVICE --device $DEVICE | grep DEVICE_NAME)
+		if [ -z "$DEVICE_NAME" ]; then
+			DEVICE=
+			continue
+		fi
+		DEVICE_LINE="
+\Zb\Z3$DEVICE_NAME\Zn
+"
+		if [ "$DEVICE_SELECTED" -eq 1 ]; then
+			TITLE="The selected device is"
+		else
+			TITLE="We detected this device as"
+		fi
+		DEVICE_CONFIRMATION="$TITLE:
+$DEVICE_LINE
+Flashing incorrect firmware will
+likely make your device unbootable.
+
+You can select your device from
+manually from the list.
+
+Proceed with the current device?"
+
+		dialog --yes-label 'Continue' --no-label 'Select' \
+		       --yesno "$DEVICE_CONFIRMATION" 0 0
+		if [ $? -eq 0 ] ; then
+			break
+		fi
+	else
+		DEVICE_WARNING="\Zb\Z1We could not detect your device\Zn
+
+Flashing incorrect firmware will
+likely make your device unbootable.
+
+Please CAREFULLY select your device
+manually from the list."
+
+		dialog --defaultno --yes-label 'Select' --no-label 'Exit' \
+		       --yesno "$DEVICE_WARNING" 0 0
+		if [ $? -ne 0 ] ; then
+			exit $?
+		fi
+	fi
+
+	exec 3>&1
+	NEW_DEVICE=$($THISDEVICE --devices $1 | while read i; do
+		echo $i | cut -d'-' -f1 | xargs
+		echo $i | cut -d'-' -f2- | xargs
+	done | tr \\n \\0 | xargs -0 \
+		dialog --menu "Select your device from the list" 0 0 3 \
+		2>&1 1>&3)
+	EXIT_STATUS=$?
+	exec 3>&-
+	if [ $EXIT_STATUS -ne 0 ] ; then
+		continue
+	fi
+
+	DEVICE=$NEW_DEVICE
+	DEVICE_SELECTED=1
+done
+
+# ----------
+# 2. Final confirmation
+# ----------
 DISCLAIMER="\Zb\Z3NOTICE\Zn
 
 While we carefully constructed this
@@ -16,30 +95,27 @@ you perform the update.
 
 Do you want to update now?"
 
-UP_TO_DATE=yes
-
-if [ -f "$DATE_FILE" ] ; then
-	DATE="`cat $DATE_FILE`"
-	export DIALOGOPTS="--colors --no-shadow --backtitle \"OpenDingux update $DATE\""
-fi
-
-echo "screen_color = (RED,RED,ON)" > /tmp/dialog_err.rc
-
 dialog --defaultno --yes-label 'Update' --no-label 'Cancel' --yesno "$DISCLAIMER" 0 0
 if [ $? -ne 0 ] ; then
 	exit $?
 fi
 
+# ----------
+# 3. Flashing
+# ----------
 clear
 echo 'Update in progress - please be patient.'
 echo
 
 if [ "$(whoami)" = "root" -a ! -x /usr/sbin/od-update ]; then
-	./od-update $1
+	PATH=$(pwd):$PATH FORCE_DEVICE="$DEVICE" ./od-update $1
 else
-	sudo od-update $1
+	sudo PATH=$(pwd):$PATH FORCE_DEVICE="$DEVICE" od-update $1
 fi
 
+# ----------
+# 4. Checking status
+# ----------
 ERR=$?
 if [ $ERR -ne 0 ] ; then
 	case $ERR in
@@ -92,6 +168,9 @@ if [ $ERR -ne 0 ] ; then
 	exit $ERR
 fi
 
+# ----------
+# 5. Reboot
+# ----------
 case $1 in
 	rs90)
 		LAST_KERNEL=START

--- a/board/opendingux/opk_update_script.sh
+++ b/board/opendingux/opk_update_script.sh
@@ -108,9 +108,13 @@ echo 'Update in progress - please be patient.'
 echo
 
 if [ "$(whoami)" = "root" -a ! -x /usr/sbin/od-update ]; then
-	PATH=$(pwd):$PATH FORCE_DEVICE="$DEVICE" ./od-update $1
+	./od-update "$1" "$DEVICE"
 else
-	sudo PATH=$(pwd):$PATH FORCE_DEVICE="$DEVICE" od-update $1
+	# Old firmware's od-update requires equally one argument
+	# and ENV variables are restricted by sudo
+	# so the only way to pass the device is via a tmp file
+	echo "$DEVICE" > /tmp/_force_thisdevice
+	sudo od-update $1
 fi
 
 # ----------

--- a/board/opendingux/target_skeleton/usr/bin/thisdevice
+++ b/board/opendingux/target_skeleton/usr/bin/thisdevice
@@ -104,12 +104,12 @@ case $1 in
 		if [ -z "$STORAGE" ]; then
 			STORAGE=mmc
 		fi
-		echo "$LINE" | cut -d';' -f3
-		echo -e Codename:"\t" $(echo "$LINE" | cut -d';' -f2)
-		echo -e Family:"\t\t" $(echo "$LINE" | cut -d';' -f1)
-		echo -e Bootloader:"\t" $(echo "$LINE" | cut -d';' -f4)
-		echo -e Devicetree:"\t" $(echo "$LINE" | cut -d';' -f5)
-		echo -e Storage:"\t" $STORAGE
+		echo 'DEVICE_FAMILY="'$(echo "$LINE" | cut -d';' -f1 | xargs)'"'
+		echo 'DEVICE_CODE="'$(echo "$LINE" | cut -d';' -f2 | xargs)'"'
+		echo 'DEVICE_NAME="'$(echo "$LINE" | cut -d';' -f3 | xargs)'"'
+		echo 'DEVICE_BOOTLOADER="'$(echo "$LINE" | cut -d';' -f4)'"'
+		echo 'DEVICE_DEVICETREE="'$(echo "$LINE" | cut -d';' -f5)'"'
+		echo 'DEVICE_STORAGE="'$STORAGE'"'
 		;;
 	--detect)
 		detect_device

--- a/board/opendingux/target_skeleton/usr/bin/thisdevice
+++ b/board/opendingux/target_skeleton/usr/bin/thisdevice
@@ -1,0 +1,121 @@
+#!/bin/sh
+
+display_usage() {
+	cat <<-END
+Usage $0 <command> [argument]:
+
+Available commands are:
+    --families    Show list of supported device families
+    --devices <family>
+                  Show list of devices for the given family
+    --device <device>
+                  Show device information, including bootloader and devicetree
+    --detect      Try to detect the current device
+    --help, -h    Show this message
+END
+}
+
+DEVICES=$(cat <<-END
+gcw0 ;gcw,zero        ;GCW-Zero;v20_mddr_512mb;gcw0;
+gcw0 ;gcw,zero_proto  ;GCW-Zero Prototype (256 MiB);v11_ddr2_256mb;gcw0_proto;
+gcw0 ;ylm,rg350       ;Anbernic RG-350 / RG-350P;rg350;rg350;
+gcw0 ;ylm,rg350m      ;Anbernic RG-350M (metal cover, 640x480 IPS screen);rg350;rg350m;
+gcw0 ;ylm,rg280v      ;Anbernic RG-280V;rg350;rg280v;
+gcw0 ;ylm,rg280m      ;Anbernic RG-280M;rg350;rg280m;
+gcw0 ;wolsen,playgo   ;PlayGo or PocketGo 2 second gen (v2, with a reset button);rg350;playgo;
+gcw0 ;wolsen,pocketgo2;PocketGo 2 or PlayGo first gen (v1, without a reset button);v20_mddr_512mb;pocketgo2;
+rs90 ;ylm,rs90v21     ;Anbernic RS-90 v2.1;v21;rs90;nand
+rs90 ;ylm,rs90v30     ;Anbernic RS-90 v3.0;v30;rs90;nand
+rs90 ;ylm,rg99        ;Anbernic RG-99;v21;rg99;nand
+lepus;ylm,rs97        ;Anbernic RS-97 v2.0;lepus;rs97
+lepus;ylm,rg300       ;Anbernic RG-300 non-IPS;lepus;rg300
+lepus;wolsen,ldkv     ;LDK (vertical);lepus;ldkv;
+lepus;wolsen,ldkh     ;LDK (horizontal);lepus;ldkh;
+END
+)
+
+if [ $# -le 0 ]; then
+	display_usage
+	exit 1
+fi
+
+if [ $1 = "--help" ] || [ $1 = "-h" ]; then
+	display_usage
+	exit 0
+fi
+
+detect_device() {
+	HWVARIANT_CMDLINE="$(sed -n 's/.*hwvariant=\([[:alnum:]_]\+\).*/\1/p' /proc/cmdline)"
+	DEVICE=
+	if [ -e /sys/firmware/devicetree/base/compatible ] ; then
+		DEVICE=$(sed -n 's/\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible)
+		# two versions of rs90 use the same devicetree
+		[ "$DEVICE" = ylm,rs90 ] && DEVICE="$DEVICE$HWVARIANT_CMDLINE"
+	elif [ "$HWVARIANT_CMDLINE" = "rg350" ] ; then
+		if [ -r /sys/devices/platform/jz-lcd.0/graphics/fb0/modes -a \
+		     "$(grep '640x480' /sys/devices/platform/jz-lcd.0/graphics/fb0/modes)" ] ; then
+			DEVICE=ylm,rg350m
+		elif [ "$(uname -v)" = "#128 Fri May 29 11:19:07 CST 2020" ] ; then
+			DEVICE=ylm,rg280m
+		elif [ "$(uname -v)" = "#171 Tue Jun 30 18:36:05 CST 2020" ] ; then
+			DEVICE=ylm,rg280v
+		elif [ "$(uname -v)" = "#2 Sat Mar 28 16:19:20 CST 2020" ] ; then
+			DEVICE=wolsen,playgo
+		else
+			DEVICE=ylm,rg350
+		fi
+	else
+		case "$HWVARIANT_CMDLINE" in
+			"GCW Zero"|v20_mddr_512mb)
+				DEVICE=gcw,zero
+				;;
+			*)
+				DEVICE=gcw,zero_proto
+				;;
+		esac
+	fi
+	echo $DEVICE
+}
+
+case $1 in
+	--families)
+		echo "$DEVICES" | cut -d';' -f1 | uniq
+		;;
+	--devices)
+		FAMILY=$2
+		if ! echo "$DEVICES" | cut -d';' -f1 | grep -qe "^$FAMILY[[:space:]]*$"; then
+			echo "unknown family $FAMILY (--families will show all families)" 1>&2
+			exit 1
+		fi
+
+		echo "$DEVICES" | grep -e "^$FAMILY" | while read i; do
+			echo "$(echo "$i" | cut -d';' -f2)" - $(echo $i | cut -d';' -f3)
+		done
+		;;
+	--device)
+		DEVICE=$2
+		if ! echo "$DEVICES" | grep -qe ";$DEVICE[[:space:]]*;"; then
+			echo "unknown device $DEVICE (--devices will show all devices)" 1>&2
+			exit 1
+		fi
+
+		LINE=$(echo "$DEVICES" | grep -e ";$DEVICE" | head -n1)
+		STORAGE=$(echo "$LINE" | cut -d';' -f6)
+		if [ -z "$STORAGE" ]; then
+			STORAGE=mmc
+		fi
+		echo "$LINE" | cut -d';' -f3
+		echo -e Codename:"\t" $(echo "$LINE" | cut -d';' -f2)
+		echo -e Family:"\t\t" $(echo "$LINE" | cut -d';' -f1)
+		echo -e Bootloader:"\t" $(echo "$LINE" | cut -d';' -f4)
+		echo -e Devicetree:"\t" $(echo "$LINE" | cut -d';' -f5)
+		echo -e Storage:"\t" $STORAGE
+		;;
+	--detect)
+		detect_device
+		;;
+	*)
+		echo "invalid command $1 (-h will show valid options)" 1>&2
+		exit 1
+		;;
+esac

--- a/board/opendingux/target_skeleton/usr/sbin/od-update
+++ b/board/opendingux/target_skeleton/usr/sbin/od-update
@@ -1,8 +1,39 @@
 #!/bin/sh
 
-if [ $# -ne 1 ] ; then
-	echo "Incorrect number of parameters.\nUsage:\n\tod-update <data_dir>"
+if [ $# -ne 1 ]; then
+	echo -e "Incorrect number of parameters.
+Usage:
+\t$0 <data_dir>"
 	exit 1
+fi
+
+if [ -z "$FORCE_DEVICE" ]; then
+	DEVICE=$(thisdevice --detect)
+	[ -z "$DEVICE" ] && DEVICE=undetected
+else
+	DEVICE="$FORCE_DEVICE"
+fi
+
+DEVICEINFO=$(thisdevice --device "$DEVICE" 2> /dev/null)
+if [ $? -ne 0 ] ; then
+	echo "Unknown device $DEVICE"
+	exit 12
+fi
+
+eval "$DEVICEINFO"
+
+BOOTLD=$1/ubiboot-$DEVICE_BOOTLOADER.bin
+DEVICETREE=$1/$DEVICE_DEVICETREE.dtb
+
+if [ ! -r "$BOOTLD" ]; then
+	echo "Bootloader $2 does not exists"
+	exit 13
+fi
+
+[ ! -r $DEVICETREE ] && DEVICETREE=/sys/firmware/fdt
+if [ ! -r "$DEVICETREE" ]; then
+	echo "Device tree $3 does not exists"
+	exit 14
 fi
 
 $(sed -n 's/.*root=\([[:alnum:]:\/]\+\).*rootfstype=\([[:alpha:]]\+\).*/export SYSPART=\1\nexport SYSPART_TYPE=\2/p' /proc/cmdline)
@@ -12,83 +43,22 @@ $(sed -n 's/.*root=\([[:alnum:]:\/]\+\).*rootfstype=\([[:alpha:]]\+\).*/export S
 [ -z "$SYSPART" ] && export SYSPART=/dev/mmcblk0p1
 [ -z "$SYSPART_TYPE" ] && export SYSPART_TYPE=vfat
 
-HWVARIANT_BL=""
-HWVARIANT_DT=""
-
-HWVARIANT_CMDLINE="$(sed -n 's/.*hwvariant=\([[:alnum:]_]\+\).*/\1/p' /proc/cmdline)"
-
-if [ -e /sys/firmware/devicetree/base/compatible ] ; then
-	MODEL=$(sed -n 's/\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible)
-	HWVARIANT=$(cat /sys/firmware/devicetree/base/model)
-elif [ "$HWVARIANT_CMDLINE" = "rg350" ] ; then
-	if [ -r /sys/devices/platform/jz-lcd.0/graphics/fb0/modes -a \
-		"$(grep '640x480' /sys/devices/platform/jz-lcd.0/graphics/fb0/modes)" ] ; then
-		MODEL=ylm,rg350m
-	elif [ "$(uname -v)" = "#128 Fri May 29 11:19:07 CST 2020" ] ; then
-		MODEL=ylm,rg280m
-	elif [ "$(uname -v)" = "#171 Tue Jun 30 18:36:05 CST 2020" ] ; then
-		MODEL=ylm,rg280v
-	elif [ "$(uname -v)" = "#2 Sat Mar 28 16:19:20 CST 2020" ] ; then
-		MODEL=wolsen,playgo
-	else
-		MODEL=ylm,rg350
-	fi
-else
-	MODEL=gcw,zero
-	HWVARIANT="$HWVARIANT_CMDLINE"
-fi
-
 # Default to SYSDEV=/dev/mmcblk0
 SYSDEV=$(echo $SYSPART |sed -n 's/\(\/dev\/mmcblk[0-9]\+\)p[0-9]\+/\1/p')
 
-[ "$MODEL" = "retromini" ] && MODEL=ylm,rs90
-
-case "$MODEL" in
-	ylm,rs90|ylm,pmp5|ylm,rg99)
-		HWVARIANT_BL="$HWVARIANT_CMDLINE"
-		HWVARIANT_DT=$(echo $MODEL |cut -d',' -f2)
-		INSTALL_ON_NAND=Y
-		SYSDEV=/dev/mtd0
-		;;
-	ylm,rs97|ylm,rg300|wolsen,ldkv|wolsen,ldkh)
-		HWVARIANT_BL="lepus"
-		HWVARIANT_DT=$(echo $MODEL |cut -d',' -f2)
-		;;
-	gcw,zero)
-		case "$HWVARIANT" in
-			"GCW Zero"|v20_mddr_512mb)
-				HWVARIANT_BL="v20_mddr_512mb"
-				HWVARIANT_DT="gcw0"
-				;;
-			*)
-				HWVARIANT_BL="v11_ddr2_256mb"
-				HWVARIANT_DT="gcw0_proto"
-				;;
-		esac
-		;;
-	anbernic,rg350|anbernic,rg350m|ylm,rg350|ylm,rg350m|ylm,rg280m|ylm,rg280v|wolsen,playgo)
-		HWVARIANT_DT=$(echo $MODEL |cut -d',' -f2)
-		HWVARIANT_BL="rg350"
-		;;
-	*)
-		echo "Unknown model $MODEL"
-		exit 1
-		;;
-esac
+if [ "$DEVICE_STORAGE" = 'nand' ];then
+	INSTALL_ON_NAND=Y
+	SYSDEV=/dev/mtd0
+fi
 
 MNT=/mnt/_system_update
 [ "$(grep kernel_bak /proc/cmdline)" ] && KERNEL_IS_BACKUP=Y
 [ "$(grep rootfs_bak /proc/cmdline)" ] && ROOTFS_IS_BACKUP=Y
 
-BOOTLD=$1/ubiboot-${HWVARIANT_BL}.bin
 KERNEL=$1/uzImage.bin
 ROOTFS=$1/rootfs.squashfs
 MODULES_FS=$1/modules.squashfs
 MININIT=$1/mininit-syspart
-DEVICETREE=$1/${HWVARIANT_DT}.dtb
-
-[ ! -r $DEVICETREE ] && DEVICETREE=/sys/firmware/fdt
-
 
 handle_err() {
 	rm -f $MNT/new_uzImage.bin $MNT/new-rootfs.squashfs \

--- a/board/opendingux/target_skeleton/usr/sbin/od-update
+++ b/board/opendingux/target_skeleton/usr/sbin/od-update
@@ -1,20 +1,29 @@
 #!/bin/sh
 
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ]; then
 	echo -e "Incorrect number of parameters.
 Usage:
-\t$0 <data_dir>"
+\t$0 <data_dir> [device]"
 	exit 1
 fi
 
-if [ -z "$FORCE_DEVICE" ]; then
-	DEVICE=$(thisdevice --detect)
-	[ -z "$DEVICE" ] && DEVICE=undetected
+if [ -x ./thisdevice ]; then
+	THISDEVICE=./thisdevice
 else
-	DEVICE="$FORCE_DEVICE"
+	THISDEVICE=$(which thisdevice 2> /dev/null)
 fi
 
-DEVICEINFO=$(thisdevice --device "$DEVICE" 2> /dev/null)
+if [ -z "$THISDEVICE" ]; then
+	echo "thisdevice utility can't be found"
+	exit 12
+fi
+
+[ -z "$DEVICE" ] && DEVICE=$2
+[ -z "$DEVICE" -a -r /tmp/_force_thisdevice ] && DEVICE=$(cat /tmp/_force_thisdevice)
+[ -z "$DEVICE" ] && DEVICE=$($THISDEVICE --detect)
+[ -z "$DEVICE" ] && DEVICE=undetected
+
+DEVICEINFO=$($THISDEVICE --device "$DEVICE" 2> /dev/null)
 if [ $? -ne 0 ] ; then
 	echo "Unknown device $DEVICE"
 	exit 12
@@ -26,13 +35,13 @@ BOOTLD=$1/ubiboot-$DEVICE_BOOTLOADER.bin
 DEVICETREE=$1/$DEVICE_DEVICETREE.dtb
 
 if [ ! -r "$BOOTLD" ]; then
-	echo "Bootloader $2 does not exists"
+	echo "Bootloader $DEVICE_BOOTLOADER does not exists"
 	exit 13
 fi
 
 [ ! -r $DEVICETREE ] && DEVICETREE=/sys/firmware/fdt
 if [ ! -r "$DEVICETREE" ]; then
-	echo "Device tree $3 does not exists"
+	echo "Device tree $DEVICE_DEVICETREE does not exists"
 	exit 14
 fi
 
@@ -99,7 +108,7 @@ if [ -r $ROOTFS -a "$0" != "/tmp/od-update" ] ; then
 			umount $MNT
 
 			# Run the updated od-update script from the rootfs
-			exec /tmp/od-update $*
+			exec /tmp/od-update "$@"
 		else
 			umount $MNT
 		fi


### PR DESCRIPTION
The device detection is unreliable and often gives inaccurate results that can lead to bricks. This PR adds one step to confirm the detected device + to select the current device manually.

Signed-off-by: Sergiy Kukunin <sergey.kukunin@gmail.com>