### PR TITLE
Add CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,152 @@
+name: OpenDingux_buildroot
+
+on:
+  push:
+    branches:
+      - opendingux
+  pull_request:
+    branches:
+      - opendingux
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/opendingux/retro-toolchain/buildroot
+
+    strategy:
+      matrix:
+        target: ['lepus', 'gcw0', 'rs90']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - name: Blocked invisible-mirror.net workaround
+      run: echo "1.1.1.1 invisible-mirror.net" | tee -a /etc/hosts
+    - name: Cache downloads
+      id: cache-downloads
+      uses: actions/cache@v2
+      with:
+        path: dl
+        key: downloads
+    - name: build
+      run: ./rebuild.sh
+      env:
+        CONFIG: ${{ matrix.target }}
+        BR2_JLEVEL: 0
+        FORCE_UNSAFE_CONFIGURE: 1
+    - uses: actions/upload-artifact@v2
+      with:
+        name: toolchain-${{ matrix.target }}
+        path: |
+          output/${{ matrix.target }}/images/*.tar*
+    - uses: actions/upload-artifact@v2
+      with:
+        name: update-${{ matrix.target }}
+        path: |
+          output/${{ matrix.target }}/images/*.opk
+
+  build-installer:
+    name: Build installer
+    runs-on: ubuntu-20.04
+    needs: build
+    container:
+      image: ghcr.io/opendingux/retro-toolchain/buildroot
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - uses: actions/download-artifact@v2
+      with:
+        name: toolchain-rs90
+    - name: Decompress RS90 toolchain
+      run: tar xf opendingux-rs90-*tar.xz
+    - name: Blocked invisible-mirror.net workaround
+      run: echo "1.1.1.1 invisible-mirror.net" | tee -a /etc/hosts
+    - name: Cache downloads
+      id: cache-downloads
+      uses: actions/cache@v2
+      with:
+        path: dl
+        key: downloads
+    - name: set external toolchain path
+      run: |
+        echo "BR2_TOOLCHAIN_EXTERNAL_PATH=\"$(pwd)/rs90-toolchain\"" >> configs/od_installer_defconfig
+        echo "BR2_TOOLCHAIN_EXTERNAL_PREINSTALLED=y" >> configs/od_installer_defconfig
+        echo "BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=n" >> configs/od_installer_defconfig
+    - name: build
+      run: ./rebuild.sh
+      env:
+        CONFIG: installer
+        BR2_JLEVEL: 0
+        FORCE_UNSAFE_CONFIGURE: 1
+    - uses: actions/upload-artifact@v2
+      with:
+        name: odboot-client-linux
+        path: |
+          output/installer/images/odboot-client
+    - uses: actions/upload-artifact@v2
+      with:
+        name: vmlinuz
+        path: |
+          output/installer/images/vmlinuz.bin
+
+  build-win:
+    name: Build odbootd (Windows)
+    runs-on: windows-2019
+    needs: build-installer
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: false
+        msystem: mingw64
+        install: >-
+          base-devel
+          git
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-libusb
+    - uses: actions/checkout@v2
+      with:
+        repository: 'pcercuei/libini'
+        path: 'libini'
+    - name: Configure, build and install libini
+      run: |
+        cmake -Bbuild -G "MSYS Makefiles" -DBUILD_SHARED_LIBS=OFF
+        cmake --build build --config Release --parallel
+        cmake --install build --prefix /usr
+      working-directory: libini
+    - uses: actions/checkout@v2
+      with:
+        repository: 'pcercuei/libopk'
+        path: 'libopk'
+    - name: Configure, build and install libopk
+      run: |
+        PKG_CONFIG_PATH=/usr/lib/pkgconfig cmake -Bbuild -G "MSYS Makefiles" -DBUILD_SHARED_LIBS=OFF
+        cmake --build build --config Release --target opk
+        cmake --install build --prefix /usr
+      working-directory: libopk
+    - uses: actions/checkout@v2
+      with:
+        repository: 'OpenDingux/odbootd'
+        path: 'odbootd'
+    - uses: actions/download-artifact@v2
+      with:
+        name: vmlinuz
+        path: odbootd
+    - name: Configure, build and package odbootd
+      run: |
+        PKG_CONFIG_PATH=/usr/lib/pkgconfig cmake -DWITH_ODBOOTD=OFF -DSTATIC_EXE=ON -DEMBEDDED_INSTALLER=vmlinuz.bin -Bbuild -G "MSYS Makefiles"
+        cmake --build build --config Release
+      working-directory: odbootd
+    - uses: actions/upload-artifact@v2
+      with:
+        name: odboot-client-windows
+        path: |
+          odbootd/build/odboot-client.exe
+


### PR DESCRIPTION
As mentioned over IRC, adding CI builds, including toolchain, update & odboot-client for Linux and Windows. macOS will be added at a later time.