### PR TITLE
opendingux: use utils/brmake on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,14 @@ jobs:
       matrix:
         target: ['lepus', 'gcw0', 'rs90']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Blocked invisible-mirror.net workaround
       run: echo "1.1.1.1 invisible-mirror.net" | tee -a /etc/hosts
     - name: Cache downloads
       id: cache-downloads
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: dl
         key: downloads
@@ -38,7 +38,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         file(APPEND $ENV{GITHUB_OUTPUT} "timestamp=${current_date}\n")
     - name: ccache cache files
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v3
       with:
         path: output/ccache/${{ matrix.target }}
         key: ${ { matrix.config.name } }-ccache-${ { steps.ccache_cache_timestamp.outputs.timestamp } }
@@ -50,12 +50,12 @@ jobs:
         CONFIG: ${{ matrix.target }}
         BR2_JLEVEL: 0
         FORCE_UNSAFE_CONFIGURE: 1
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: toolchain-${{ matrix.target }}
         path: |
           output/${{ matrix.target }}/images/*.tar*
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: update-${{ matrix.target }}
         path: |
@@ -73,13 +73,13 @@ jobs:
         CONFIG: installer
         BR2_JLEVEL: 0
         FORCE_UNSAFE_CONFIGURE: 1
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ matrix.target == 'rs90' }}
       with:
         name: odboot-client-linux
         path: |
           output/installer/images/odboot-client
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ matrix.target == 'rs90' }}
       with:
         name: vmlinuz
@@ -137,7 +137,7 @@ jobs:
         PKG_CONFIG_PATH=/usr/lib/pkgconfig cmake -DWITH_ODBOOTD=OFF -DSTATIC_EXE=ON -DEMBEDDED_INSTALLER=vmlinuz.bin -Bbuild -G "MSYS Makefiles"
         cmake --build build --config Release
       working-directory: odbootd
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: odboot-client-windows
         path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
       run: ./rebuild.sh
       env:
         CONFIG: ${{ matrix.target }}
+        TOP_MAKE_COMMAND: utils/brmake
         BR2_JLEVEL: 0
         FORCE_UNSAFE_CONFIGURE: 1
     - uses: actions/upload-artifact@v3
@@ -60,6 +61,12 @@ jobs:
         name: update-${{ matrix.target }}
         path: |
           output/${{ matrix.target }}/images/*.opk
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ matrix.target }}-log
+        path: |
+          br.log
     - name: Build installer
       if: ${{ matrix.target == 'rs90' }}
       run: |
@@ -71,6 +78,7 @@ jobs:
         ./rebuild.sh
       env:
         CONFIG: installer
+        TOP_MAKE_COMMAND: utils/brmake
         BR2_JLEVEL: 0
         FORCE_UNSAFE_CONFIGURE: 1
     - uses: actions/upload-artifact@v3
@@ -85,6 +93,12 @@ jobs:
         name: vmlinuz
         path: |
           output/installer/images/vmlinuz.bin
+    - uses: actions/upload-artifact@v3
+      if: ${{ matrix.target == 'rs90' && always() }}
+      with:
+        name: ${{ matrix.target }}-installer-log
+        path: |
+          br.log
 
   build-win:
     name: Build odbootd (Windows)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
+        file(APPEND $ENV{GITHUB_OUTPUT} "timestamp=${current_date}\n")
     - name: ccache cache files
       uses: actions/cache@v1.1.0
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.rej
 *~
 *.pyc
+br.log

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,13 @@ if [ -z "$CONFIG" ] ; then
 	exit 1
 fi
 
+# Set TOP_MAKE_COMMAND to utils/brmake for compact output
+TOP_MAKE_COMMAND="${TOP_MAKE_COMMAND:-make}"
+
+if [ "$TOP_MAKE_COMMAND" = utils/brmake ]; then
+	rm -f br.log
+fi
+
 # Clear the build location.
 if [ "$1" = clean ]; then
   echo "Clearing build location..."
@@ -32,7 +39,7 @@ fi
 echo "Starting build..."
 PARALLELISM=$(getconf _NPROCESSORS_ONLN)
 for target in $TARGETS; do
-	nice make "$target" BR2_SDK_PREFIX=${CONFIG}-toolchain O=output/${CONFIG} -j $PARALLELISM
+	nice ${TOP_MAKE_COMMAND} "$target" BR2_SDK_PREFIX=${CONFIG}-toolchain O=output/${CONFIG} -j $PARALLELISM
 done
 
 if [ "${TARGETS}" = sdk ] ; then


### PR DESCRIPTION
utils/brmake produces compact output with timestamps that looks like this:

```
Starting build...
2022-10-29T15:55:14 >>>   Finalizing host directory
2022-10-29T15:55:17 >>>   Finalizing target directory
2022-10-29T15:55:19 >>>   Sanitizing RPATH in target tree
2022-10-29T15:55:19 >>>   Sanity check in overlay board/opendingux/installer/overlay
2022-10-29T15:55:19 >>>   Copying overlay board/opendingux/installer/overlay
2022-10-29T15:55:19 >>>   Executing post-build script board/opendingux/installer/cleanup-rootfs.sh
2022-10-29T15:55:19 >>>   Generating root filesystems common tables
2022-10-29T15:55:19 >>>   Generating filesystem image rootfs.cpio
2022-10-29T15:55:19 >>>   Rebuilding kernel with initramfs
Done in 15s
```

The full log is available as an artifact, and now also includes timestamps.

Based on top of #85 