### PR TITLE
opendingux: add -q to killall -USR1 gmenu2x

### DIFF
--- a/board/opendingux/target_skeleton/etc/udev/rules.d/61-usb.rules
+++ b/board/opendingux/target_skeleton/etc/udev/rules.d/61-usb.rules
@@ -1,7 +1,7 @@
 SUBSYSTEM!="power_supply", GOTO="usb_end"
 ENV{POWER_SUPPLY_NAME}!="usb-charger", GOTO="usb_end"
 
-ENV{POWER_SUPPLY_ONLINE}=="1", RUN+="/usr/sbin/usb start", RUN+="/usr/bin/killall -USR1 /usr/libexec/gmenu2x"
-ENV{POWER_SUPPLY_ONLINE}=="0", RUN+="/usr/sbin/usb stop", RUN+="/usr/bin/killall -USR1 /usr/libexec/gmenu2x"
+ENV{POWER_SUPPLY_ONLINE}=="1", RUN+="/usr/sbin/usb start", RUN+="/usr/bin/killall -q -USR1 /usr/libexec/gmenu2x"
+ENV{POWER_SUPPLY_ONLINE}=="0", RUN+="/usr/sbin/usb stop", RUN+="/usr/bin/killall -q -USR1 /usr/libexec/gmenu2x"
 
 LABEL="usb_end"


### PR DESCRIPTION
Avoids polluting udev log when the cable is (un)plugged while something other than gmenu2x is running.
