### PR TITLE
od: Simplify model query in scripts

### DIFF
--- a/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
@@ -13,7 +13,7 @@ case "$1" in
 			/usr/bin/amixer set $CONTROL `cat $VOLUME_STATEFILE`
 		fi
 
-		MODEL=$(sed -n 's/\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible)
+		IFS= read -r -d $'\0' MODEL </sys/firmware/devicetree/base/compatible
 		case "$MODEL" in
 			wolsen,pocketgo2v2|ylm,rg280m|ylm,rg300x|ylm,rg350|ylm,rg350m)
 				amixer set Mixer Playback 45%

--- a/board/opendingux/rs90/overlay/etc/init.d/S98usb.sh
+++ b/board/opendingux/rs90/overlay/etc/init.d/S98usb.sh
@@ -2,7 +2,7 @@
 
 USB_MODE=mtp
 
-MODEL=`sed -n 's/\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible`
+IFS= read -r -d $'\0' MODEL </sys/firmware/devicetree/base/compatible
 
 case "$MODEL" in
 	# Only the RS90 needs to start USB at bootup, because it does not have

--- a/board/opendingux/target_skeleton/etc/init.d/S05hostname.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S05hostname.sh
@@ -2,7 +2,7 @@
 
 [ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
 
-MODEL=$(sed -n 's/\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible)
+IFS= read -r -d $'\0' MODEL </sys/firmware/devicetree/base/compatible
 
 case "$MODEL" in
 	gcw,zero)

--- a/board/opendingux/target_skeleton/etc/profile
+++ b/board/opendingux/target_skeleton/etc/profile
@@ -1,7 +1,8 @@
 export PAGER='/bin/less'
 export EDITOR='/bin/nano'
 export PATH=/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-export MODEL="$(sed -n 's/\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible)"
+IFS= read -r -d $'\0' MODEL </sys/firmware/devicetree/base/compatible
+export MODEL
 
 if [ "$PS1" ]; then
 	if [ "`id -u`" -eq 0 ]; then

--- a/board/opendingux/target_skeleton/usr/sbin/od-update
+++ b/board/opendingux/target_skeleton/usr/sbin/od-update
@@ -18,7 +18,7 @@ HWVARIANT_DT=""
 HWVARIANT_CMDLINE="$(sed -n 's/.*hwvariant=\([[:alnum:]_]\+\).*/\1/p' /proc/cmdline)"
 
 if [ -e /sys/firmware/devicetree/base/compatible ] ; then
-	MODEL=$(sed -n 's/\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible)
+	IFS= read -r -d $'\0' MODEL </sys/firmware/devicetree/base/compatible
 	if [ -e /sys/firmware/devicetree/base/model ] ; then
 		HWVARIANT=$(cat /sys/firmware/devicetree/base/model)
 	fi


### PR DESCRIPTION
`/sys/firmware/devicetree/base/compatible` is `\0`-delimited.

Instead of relying on `\0`-removal and stripping the `ingenic.*` suffix, simply read the string up to the first `\0`.