### PR TITLE
od: valgrind: disable LTO

### DIFF
--- a/board/opendingux/package/valgrind/valgrind.mk
+++ b/board/opendingux/package/valgrind/valgrind.mk
@@ -1,0 +1,2 @@
+# Valgrind LTO takes over an hour to link for gcw0.
+VALGRIND_CONF_OPTS += --disable-lto


### PR DESCRIPTION
Valgrind takes over an hour to link for gcw0.

A buildroot patch adding a valgrind-specific setting was rejected upstream:
https://patchwork.ozlabs.org/project/buildroot/patch/20210418183658.1675843-1-glex.spb@gmail.com/

Until there is a better solution upstream, disable LTO via a Makefile addition in
board/opendingux/package/valgrind/valgrind.mk
