### PR TITLE
od: Fix S98usb.sh exiting rcS

### DIFF
--- a/board/opendingux/rs90/overlay/etc/init.d/S98usb.sh
+++ b/board/opendingux/rs90/overlay/etc/init.d/S98usb.sh
@@ -10,7 +10,7 @@ case "$MODEL" in
 	ylm,rs90)
 		;;
 	*)
-		exit 0
+		return 0
 		;;
 esac
 


### PR DESCRIPTION
`exit` in a sourced script exits the entire `rcS`. Use `return 0` instead.