### PR TITLE
od: Fix a couple more exits in init scripts

### DIFF
--- a/board/opendingux/gcw0/overlay/etc/init.d/S50bluetooth.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S50bluetooth.sh
@@ -20,5 +20,3 @@ case "$1" in
 		echo "Usage: $0 {start|stop}"
 		exit 1
 esac
-
-exit $?

--- a/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
@@ -30,5 +30,3 @@ case "$1" in
 		echo "Usage: $0 {start|stop}"
 		exit 1
 esac
-
-exit $?

--- a/board/opendingux/lepus/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/lepus/overlay/etc/init.d/S90volume.sh
@@ -21,5 +21,3 @@ case "$1" in
 		echo "Usage: $0 {start|stop}"
 		exit 1
 esac
-
-exit $?

--- a/board/opendingux/target_skeleton/etc/init.d/S09swap.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S09swap.sh
@@ -9,7 +9,7 @@ SWAP_COMPRESSOR=lzo-rle
 # User overrides.
 [ -r /usr/local/etc/swap.conf ] && . /usr/local/etc/swap.conf
 
-[ $SWAP_PERCENT_MEM -gt 0 ] || exit 0
+[ $SWAP_PERCENT_MEM -gt 0 ] || return 0
 
 psplash_write "Setup swap..."
 

--- a/board/opendingux/target_skeleton/etc/init.d/S90brightness.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S90brightness.sh
@@ -24,5 +24,3 @@ case "$1" in
 		echo "Usage: $0 {start|stop}"
 		exit 1
 esac
-
-exit $?


### PR DESCRIPTION
`exit` exits `rcS` instead of the sourced script.