### PR TITLE
od: Avoid subshell in rcS and rcK

### DIFF
--- a/board/opendingux/gcw0/overlay/etc/init.d/S50bluetooth.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S50bluetooth.sh
@@ -18,5 +18,5 @@ case "$1" in
 		;;
 	*)
 		echo "Usage: $0 {start|stop}"
-		exit 1
+		${EXIT:-exit} 1
 esac

--- a/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/gcw0/overlay/etc/init.d/S90volume.sh
@@ -28,5 +28,5 @@ case "$1" in
 		;;
 	*)
 		echo "Usage: $0 {start|stop}"
-		exit 1
+		${EXIT:-exit} 1
 esac

--- a/board/opendingux/lepus/overlay/etc/init.d/S90volume.sh
+++ b/board/opendingux/lepus/overlay/etc/init.d/S90volume.sh
@@ -19,5 +19,5 @@ case "$1" in
 		;;
 	*)
 		echo "Usage: $0 {start|stop}"
-		exit 1
+		${EXIT:-exit} 1
 esac

--- a/board/opendingux/rs90/overlay/etc/init.d/S49alsa-hack.sh
+++ b/board/opendingux/rs90/overlay/etc/init.d/S49alsa-hack.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 psplash_write "Setup ALSA hack..."
 

--- a/board/opendingux/rs90/overlay/etc/init.d/S98usb.sh
+++ b/board/opendingux/rs90/overlay/etc/init.d/S98usb.sh
@@ -10,7 +10,7 @@ case "$MODEL" in
 	ylm,rs90)
 		;;
 	*)
-		return 0
+		${EXIT:-exit} 0
 		;;
 esac
 

--- a/board/opendingux/target_skeleton/etc/init.d/S02hugepages.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S02hugepages.sh
@@ -3,7 +3,7 @@
 NR_HUGEPAGES=8
 [ -r /etc/default/hugepages ] && . /etc/default/hugepages
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 if [ -d /sys/kernel/mm/hugepages/hugepages-2048kB ] ; then
 	psplash_write "Configuring huge pages..."

--- a/board/opendingux/target_skeleton/etc/init.d/S02modules.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S02modules.sh
@@ -11,7 +11,7 @@ case "$1" in
 
 		if [ "`grep '/lib/modules' /proc/mounts`" ] ; then
 			echo 'Modules filesystem is already mounted' >&2
-			exit 1
+			${EXIT:-exit} 1
 		fi
 
 		if [ -r "$MODULES_FILESYSTEM" ] ; then
@@ -29,5 +29,5 @@ case "$1" in
 
 	*)
 		echo "Usage: $0 {start|stop}"
-		exit 1
+		${EXIT:-exit} 1
 esac

--- a/board/opendingux/target_skeleton/etc/init.d/S03mountdata.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S03mountdata.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 mkdir -p /media/data
 

--- a/board/opendingux/target_skeleton/etc/init.d/S04localfsinit.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S04localfsinit.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 psplash_write "Initializing filesystem..."
 

--- a/board/opendingux/target_skeleton/etc/init.d/S05hostname.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S05hostname.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 IFS= read -r -d $'\0' MODEL </sys/firmware/devicetree/base/compatible
 

--- a/board/opendingux/target_skeleton/etc/init.d/S09passwd.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S09passwd.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 if [ ! -f /usr/local/etc/shadow ]; then
 	echo 'od:*:::::::' > /usr/local/etc/shadow

--- a/board/opendingux/target_skeleton/etc/init.d/S09swap.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S09swap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 SWAP_PERCENT_MEM=80
 SWAPPINESS=20
@@ -9,7 +9,7 @@ SWAP_COMPRESSOR=lzo-rle
 # User overrides.
 [ -r /usr/local/etc/swap.conf ] && . /usr/local/etc/swap.conf
 
-[ $SWAP_PERCENT_MEM -gt 0 ] || return 0
+[ $SWAP_PERCENT_MEM -gt 0 ] || ${EXIT:-exit} 0
 
 psplash_write "Setup swap..."
 

--- a/board/opendingux/target_skeleton/etc/init.d/S49dropbear-keys.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S49dropbear-keys.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 mkdir -p /etc/local/dropbear
 

--- a/board/opendingux/target_skeleton/etc/init.d/S90brightness.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S90brightness.sh
@@ -22,5 +22,5 @@ case "$1" in
 		;;
 	*)
 		echo "Usage: $0 {start|stop}"
-		exit 1
+		${EXIT:-exit} 1
 esac

--- a/board/opendingux/target_skeleton/etc/init.d/S97perms.sh
+++ b/board/opendingux/target_skeleton/etc/init.d/S97perms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" ] || [ "x$1" = "xstart" ] || exit 0
+[ -z "$1" ] || [ "x$1" = "xstart" ] || ${EXIT:-exit} 0
 
 psplash_write "Setup permissions..."
 

--- a/package/initscripts/init.d/rcK
+++ b/package/initscripts/init.d/rcK
@@ -12,11 +12,9 @@ for i in $(ls -r /etc/init.d/S??*) ;do
      case "$i" in
 	*.sh)
 	    # Source shell script for speed.
-	    (
-		trap - INT QUIT TSTP
+		EXIT=return
 		set stop
 		. $i
-	    )
 	    ;;
 	*)
 	    # No sh extension, so fork subprocess.

--- a/package/initscripts/init.d/rcS
+++ b/package/initscripts/init.d/rcS
@@ -12,11 +12,9 @@ for i in /etc/init.d/S??* ;do
      case "$i" in
 	*.sh)
 	    # Source shell script for speed.
-	    (
-		trap - INT QUIT TSTP
+		EXIT=return
 		set start
 		. $i
-	    )
 	    ;;
 	*)
 	    # No sh extension, so fork subprocess.


### PR DESCRIPTION
We previously used `( ... )` subprocess for each init script to prevent the `exit` command from exiting `rcS/K`.

Instead, define the `EXIT=return` in `rcS/K` and use `${EXIT:-exit}` in the scripts instead of the `exit` command.

`${EXIT:-exit}` will expand to `exit` if `$EXIT` is not set, allowing these scripts to be called directly as well.

This only applies to system scripts. We still use subshells in `S99localscripts.sh` to avoid breaking any user scripts.

NEEDS TESTING