### PR TITLE
package/libmodplug: Use the latest git version

### DIFF
--- a/package/libmodplug/libmodplug.hash
+++ b/package/libmodplug/libmodplug.hash
@@ -1,3 +1,3 @@
 # Locally computed:
-sha256  457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de  libmodplug-0.8.9.0.tar.gz
+sha256  d145910ca10c3ecab0019d45be7e31ea6be1d1ee951ef0e1f747c9752d20f043  libmodplug-d1b97ed.tar.gz
 sha256  49942e7b3b175f549e751feb08b5270ca6f6c5fb7a1be9f9517db275ec32c92e  COPYING

--- a/package/libmodplug/libmodplug.mk
+++ b/package/libmodplug/libmodplug.mk
@@ -4,11 +4,11 @@
 #
 ################################################################################
 
-LIBMODPLUG_VERSION = 0.8.9.0
-LIBMODPLUG_SITE = http://downloads.sourceforge.net/project/modplug-xmms/libmodplug/$(LIBMODPLUG_VERSION)
+LIBMODPLUG_VERSION = d1b97ed
+LIBMODPLUG_SITE = $(call github,Konstanty,libmodplug,$(LIBMODPLUG_VERSION))
 LIBMODPLUG_INSTALL_STAGING = YES
 LIBMODPLUG_LICENSE = Public Domain
 LIBMODPLUG_LICENSE_FILES = COPYING
 LIBMODPLUG_CPE_ID_VENDOR = konstanty_bialkowski
 
-$(eval $(autotools-package))
+$(eval $(cmake-package))


### PR DESCRIPTION
The libmodplug release has not been updated for over 5 years. The git version contains many bug fixes, including for OOB accesses, unaligned reads and writes, etc.

This git repository is the official home of libmodplug (by the original author), however a new release does not seem likely anytime soon: there are multiple open issues in the repository asking the author to tag a release, all without a response.

Update buildroot to the current version of libmodplug from the official git repository. The build system changed from autotools to cmake since the last version.

---

I've also sent this patch upstream to buildroot but we want it here regardless of whether it is accepted upstream.
https://patchwork.ozlabs.org/project/buildroot/patch/20221219173935.3085978-1-glex.spb@gmail.com/