### PR TITLE
od: Fix GitHub CI cache key variables syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: output/ccache/${{ matrix.target }}
-        key: ${ { matrix.config.name } }-ccache-${ { steps.ccache_cache_timestamp.outputs.timestamp } }
+        key: ${{ matrix.config.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
         restore-keys: |
-          ${ { matrix.config.name } }-ccache-
+          ${{ matrix.config.name }}-ccache-
     - name: build
       run: ./rebuild.sh
       env:


### PR DESCRIPTION
`${ { ... } }` is not the same as `${{ ... }}`.

It was being interpreted literally when logging,
resulting in a non-informative message, such as:

    Cache restored from key: ${ { matrix.config.name } }-ccache-${ { steps.ccache_cache_timestamp.outputs.timestamp } }