### PR TITLE
RS90: fix DAC unmuting

### DIFF
--- a/board/opendingux/rs90/overlay/etc/init.d/S49alsa-hack.sh
+++ b/board/opendingux/rs90/overlay/etc/init.d/S49alsa-hack.sh
@@ -9,4 +9,4 @@ psplash_write "Setup ALSA hack..."
 /usr/bin/aplay /usr/share/alsa/dummy.wav >/dev/null 2>&1
 
 # Unmute DAC
-amixer -q -D hw:rs90audio cset "name='Master Playback Switch'" on
+amixer -q -D hw:rs90audio cset "name='DAC Playback Switch'" on


### PR DESCRIPTION
After some changes were made in the linux 6.2 asoc driver, the dac unmute switch has been moved to the DAC control