### PR TITLE
 od: Fix sdl2 joystick translator driver 

### DIFF
--- a/board/opendingux/package/sdl2/sdl2.mk
+++ b/board/opendingux/package/sdl2/sdl2.mk
@@ -1,2 +1,6 @@
 SDL2_CONF_OPTS += --enable-joystick-translator
 SDL2_AUTORECONF = YES
+define SDL2_RUN_AUTOGEN
+	cd $(@D) && PATH=$(BR_PATH) ./autogen.sh
+endef
+SDL2_PRE_CONFIGURE_HOOKS += SDL2_RUN_AUTOGEN

--- a/board/opendingux/patches/sdl2/0001-SDL_joystick-Add-translator-joystick-driver.patch
+++ b/board/opendingux/patches/sdl2/0001-SDL_joystick-Add-translator-joystick-driver.patch
@@ -276,7 +276,7 @@ new file mode 100644
 index 0000000..75e3f6e
 --- /dev/null
 +++ b/src/joystick/translator/SDL_translator.c
-@@ -0,0 +1,492 @@
+@@ -0,0 +1,502 @@
 +/*
 +  Simple DirectMedia Layer
 +  Copyright (C) 2021 Paul Cercueil <paul@crapouillou.net>
@@ -581,11 +581,14 @@ index 0000000..75e3f6e
 +
 +static SDL_JoystickGUID TRANSLATOR_JoystickGetDeviceGUID(int device_index)
 +{
-+    SDL_JoystickGUID guid;
-+    /* the GUID is just the first 16 chars of the name for now */
 +    const char *name = TRANSLATOR_JoystickGetDeviceName(device_index);
++    SDL_JoystickGUID guid;
++    Uint16 *guid16 = (Uint16 *)guid.data;
++
 +    SDL_zero(guid);
-+    SDL_memcpy(&guid, name, SDL_min(sizeof(guid), SDL_strlen(name)));
++    *guid16++ = SDL_SwapLE16(SDL_HARDWARE_BUS_UNKNOWN);
++    *guid16++ = SDL_SwapLE16(SDL_crc16(0, name, SDL_strlen(name)));
++    SDL_memcpy((char*)guid16, name, SDL_min(sizeof(guid) - 4, SDL_strlen(name)));
 +    return guid;
 +}
 +
@@ -743,27 +746,34 @@ index 0000000..75e3f6e
 +    return SDL_Unsupported();
 +}
 +
++static const char *
++TRANSLATOR_JoystickGetDevicePath(int device_index)
++{
++    return NULL;
++}
++
 +SDL_JoystickDriver SDL_TRANSLATOR_JoystickDriver =
 +{
-+    TRANSLATOR_JoystickInit,
-+    TRANSLATOR_JoystickGetCount,
-+    TRANSLATOR_JoystickDetect,
-+    TRANSLATOR_JoystickGetDeviceName,
-+    TRANSLATOR_JoystickGetDevicePlayerIndex,
-+    TRANSLATOR_JoystickSetDevicePlayerIndex,
-+    TRANSLATOR_JoystickGetDeviceGUID,
-+    TRANSLATOR_JoystickGetDeviceInstanceID,
-+    TRANSLATOR_JoystickOpen,
-+    TRANSLATOR_JoystickRumble,
-+    TRANSLATOR_JoystickRumbleTriggers,
-+    TRANSLATOR_JoystickHasLED,
-+    TRANSLATOR_JoystickSetLED,
-+    TRANSLATOR_JoystickSendEffect,
-+    TRANSLATOR_JoystickSetSensorsEnabled,
-+    TRANSLATOR_JoystickUpdate,
-+    TRANSLATOR_JoystickClose,
-+    TRANSLATOR_JoystickQuit,
-+    TRANSLATOR_JoystickGetGamepadMapping
++    .Init = TRANSLATOR_JoystickInit,
++    .GetCount = TRANSLATOR_JoystickGetCount,
++    .Detect = TRANSLATOR_JoystickDetect,
++    .GetDeviceName = TRANSLATOR_JoystickGetDeviceName,
++    .GetDevicePath = TRANSLATOR_JoystickGetDevicePath,
++    .GetDevicePlayerIndex = TRANSLATOR_JoystickGetDevicePlayerIndex,
++    .SetDevicePlayerIndex = TRANSLATOR_JoystickSetDevicePlayerIndex,
++    .GetDeviceGUID = TRANSLATOR_JoystickGetDeviceGUID,
++    .GetDeviceInstanceID = TRANSLATOR_JoystickGetDeviceInstanceID,
++    .Open = TRANSLATOR_JoystickOpen,
++    .Rumble = TRANSLATOR_JoystickRumble,
++    .RumbleTriggers = TRANSLATOR_JoystickRumbleTriggers,
++    .GetCapabilities = TRANSLATOR_JoystickHasLED,
++    .SetLED = TRANSLATOR_JoystickSetLED,
++    .SendEffect = TRANSLATOR_JoystickSendEffect,
++    .SetSensorsEnabled = TRANSLATOR_JoystickSetSensorsEnabled,
++    .Update = TRANSLATOR_JoystickUpdate,
++    .Close = TRANSLATOR_JoystickClose,
++    .Quit = TRANSLATOR_JoystickQuit,
++    .GetGamepadMapping = TRANSLATOR_JoystickGetGamepadMapping
 +};
 +
 +#endif /* SDL_JOYSTICK_TRANSLATOR */

--- a/board/opendingux/target_skeleton/etc/profile.d/sdl.sh
+++ b/board/opendingux/target_skeleton/etc/profile.d/sdl.sh
@@ -1,18 +1,18 @@
 case "$MODEL" in
 	ylm,rg350*)
 		# RG-350 / RG-350M: two clickable analog sticks
-		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,axis:190000006a6f79737469636b00000000:0,axis:190000006a6f79737469636b00000000:1,axis:190000006a6f79737469636b00000000:2,axis:190000006a6f79737469636b00000000:3,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,btn:kb:75,btn:kb:78,btn:kb:84,btn:kb:99,hat:kb:82:79:81:80'
-		SDL_GAMECONTROLLERCONFIG='4f70656e44696e677578204743572d5a,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftstick:b10,rightstick:b11,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b8,righttrigger:b9'
+		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,axis:1900b5c06a6f79737469636b00000000:0,axis:1900b5c06a6f79737469636b00000000:1,axis:1900b5c06a6f79737469636b00000000:2,axis:1900b5c06a6f79737469636b00000000:3,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,btn:kb:75,btn:kb:78,btn:kb:84,btn:kb:99,hat:kb:82:79:81:80'
+		SDL_GAMECONTROLLERCONFIG='000065d64f70656e44696e6775782056,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftstick:b10,rightstick:b11,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b8,righttrigger:b9'
 		;;
 	ylm,rg280m)
 		# RG-280M: One clickable analog stick
-		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,axis:190000006a6f79737469636b00000000:0,axis:190000006a6f79737469636b00000000:1,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,btn:kb:75,btn:kb:78,btn:kb:84,hat:kb:82:79:81:80'
-		SDL_GAMECONTROLLERCONFIG='4f70656e44696e677578204743572d5a,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftstick:b10,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b8,righttrigger:b9'
+		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,axis:1900b5c06a6f79737469636b00000000:0,axis:1900b5c06a6f79737469636b00000000:1,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,btn:kb:75,btn:kb:78,btn:kb:84,hat:kb:82:79:81:80'
+		SDL_GAMECONTROLLERCONFIG='000065d64f70656e44696e6775782056,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftstick:b10,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b8,righttrigger:b9'
 		;;
 	gcw,zero|wolsen,pocketgo2*)
 		# GCW-Zero, PocketGo2/PlayGo: One non-clickable analog stick
-		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,axis:190000006a6f79737469636b00000000:0,axis:190000006a6f79737469636b00000000:1,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,btn:kb:75,btn:kb:78,hat:kb:82:79:81:80'
-		SDL_GAMECONTROLLERCONFIG='4f70656e44696e677578204743572d5a,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b8,righttrigger:b9'
+		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,axis:1900b5c06a6f79737469636b00000000:0,axis:1900b5c06a6f79737469636b00000000:1,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,btn:kb:75,btn:kb:78,hat:kb:82:79:81:80'
+		SDL_GAMECONTROLLERCONFIG='000065d64f70656e44696e6775782056,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b8,righttrigger:b9'
 		;;
 	img,ci20)
 		# CI20: Don't create a gamepad
@@ -20,11 +20,11 @@ case "$MODEL" in
 	ylm,rg280v|qishenglong,gopher2*)
 		# RG-280V, Gopher2: No analog stick, with L2/R2
 		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,btn:kb:75,btn:kb:78,hat:kb:82:79:81:80'
-		SDL_GAMECONTROLLERCONFIG='4f70656e44696e677578204743572d5a,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,lefttrigger:b8,righttrigger:b9'
+		SDL_GAMECONTROLLERCONFIG='000065d64f70656e44696e6775782056,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,lefttrigger:b8,righttrigger:b9'
 		;;
 	*)
 		# Default: No analog stick, without L2/R2
 		SDL_JOYSTICK_TRANSLATOR_MAP='OpenDingux Virtual Device,btn:kb:224,btn:kb:226,btn:kb:225,btn:kb:44,btn:kb:40,btn:kb:41,btn:kb:43,btn:kb:42,hat:kb:82:79:81:80'
-		SDL_GAMECONTROLLERCONFIG='4f70656e44696e677578204743572d5a,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2'
+		SDL_GAMECONTROLLERCONFIG='000065d64f70656e44696e6775782056,OpenDingux Virtual Device,platform:Linux,a:b1,b:b0,x:b2,y:b3,back:b5,start:b4,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2'
 		;;
 esac


### PR DESCRIPTION
1. Add `JoystickGetDevicePath` needed from SDL2 2.23.1. See https://github.com/libsdl-org/SDL/commit/e551384a995a82107f97db355fb5653a5a0645d6

2. Update the GUID using the scheme required from SDL2 2.25.1. See https://github.com/libsdl-org/SDL/commit/c1e087394020a8cb9d2a04a1eabbcc23a6a5b20d

3. Run autogen.sh for the new `--enable-joystick-translator`
to be supported.