### PR TITLE
od: Simplify MODEL query in gmenu2x.sh

### DIFF
--- a/board/opendingux/package/gmenu2x/gmenu2x.sh
+++ b/board/opendingux/package/gmenu2x/gmenu2x.sh
@@ -2,7 +2,7 @@
 
 PLATFORMS=$(sed -n 's/^opkPlatforms="\(.*\)"$/\1/p' /usr/share/gmenu2x/gmenu2x.conf)
 
-MODEL=$(sed -n 's/.*,\(.*\)ingenic.*/\1/p' /sys/firmware/devicetree/base/compatible)
+IFS= read -r -d $'\0' MODEL </sys/firmware/devicetree/base/compatible
 case $MODEL in
 	rs90|gcw0)
 		;;


### PR DESCRIPTION
`/sys/firmware/devicetree/base/compatible` is `\0`-delimited.

Instead of relying on `\0`-removal and stripping the `ingenic.*` suffix, simply read the string up to the first `\0`.

Follow-up to https://github.com/OpenDingux/buildroot/pull/97 which did this for other scripts.